### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Formerly this gem had an environments setting, that has been removed pending ref
 #### Rails
 
     ## environment.rb:
-    config.gem 'rack-google-analytcs', :lib => 'rack/google-analytics'
+    config.gem 'rack-google-analytics', :lib => 'rack/google-analytics'
     config.middleware.use Rack::GoogleAnalytics, :tracker => 'UA-xxxxxx-x'
 
 


### PR DESCRIPTION
Your rails configuration code had a typo, just added an "i" :)
