### PR TITLE
added support for ip address anonymization

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ config.middleware.use Rack::GoogleAnalytics, :tracker => 'UA-xxxxxx-x'
 * `:async`      -  sets to use asynchronous tracker
 * `:multiple`   -  sets track for multiple subdomains. (must also set :domain)
 * `:top_level`  -  sets tracker for multiple top-level domains. (must also set :domain)
+* `:anonymizeIp` -  sets the tracker to remove the last octet from all IP addresses, see https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApi_gat?hl=de#_gat._anonymizeIp for details.
 
 Note: since 0.2.0 this will use the asynchronous Google Analytics tracking code, for the traditional behaviour please use:
 

--- a/lib/rack/templates/async.erb
+++ b/lib/rack/templates/async.erb
@@ -9,6 +9,9 @@
   _gaq.push(['_setDomainName', 'none']);
   _gaq.push(['_setAllowLinker', true]);
 <% end %>
+<% if @options[:anonymizeIp] %>
+  _gaq.push (['_gat._anonymizeIp']);
+<% end %>
 <% if @options[:tracker_vars]
         @options[:tracker_vars].each do |var|
 %>

--- a/lib/rack/templates/async.erb
+++ b/lib/rack/templates/async.erb
@@ -10,7 +10,7 @@
   _gaq.push(['_setAllowLinker', true]);
 <% end %>
 <% if @options[:anonymizeIp] %>
-  _gaq.push (['_gat._anonymizeIp']);
+  _gaq.push(['_gat._anonymizeIp']);
 <% end %>
 <% if @options[:tracker_vars]
         @options[:tracker_vars].each do |var|

--- a/lib/rack/templates/sync.erb
+++ b/lib/rack/templates/sync.erb
@@ -5,5 +5,8 @@ document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.
 <script type="text/javascript">
 try{
 var pageTracker = _gat._getTracker(<%= @options[:tracker].inspect %>);
+<% if @options[:anonymizeIp] %>
+_gat._anonymizeIp();
+<% end %>
 pageTracker._trackPageview();
 } catch(err) {}</script>


### PR DESCRIPTION
I added a new option 

```
:anonymizeIp => true
```

for ip address anonymization. This is useful for sites hosted in Germany in order to meet legal requirements as described under #4 in the following document (in German):

http://www.datenschutz-hamburg.de/uploads/media/GoogleAnalytics_Hinweise_fuer_Webseitenbetreiber_in_Hamburg_01.pdf

see also the api docs: 

https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApi_gat?hl=de#_gat._anonymizeIp
