### PR TITLE
Adding support for generic pushes into the async queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ track_ga_event("Users", "Login", "Standard")
 
 See https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide
 
+## Custom Push
+
+In your application controller, you may push arbritrary data. For example:
+
+```ruby
+ga_push("_addItem", "ID", "SKU")
+```
+
+
 ## Thread Safety
 
 This middleware *should* be thread safe. Although my experience in such areas is limited, having taken the advice of those with more experience; I defer the call to a shallow copy of the environment, if this is of consequence to you please review the implementation.

--- a/lib/google-analytics/instance_methods.rb
+++ b/lib/google-analytics/instance_methods.rb
@@ -45,5 +45,10 @@ module GoogleAnalytics
       ga_events.push(var)
     end
 
+    def ga_push(*attributes)
+      var = GoogleAnalytics::Push.new(attributes)
+      ga_events.push(var)
+    end
+
   end
 end

--- a/lib/rack-google-analytics.rb
+++ b/lib/rack-google-analytics.rb
@@ -4,6 +4,7 @@ require 'rack/google-analytics'
 
 require "tracking/custom_var"
 require "tracking/event"
+require "tracking/push"
 
 require "google-analytics/instance_methods"
 

--- a/lib/tracking/push.rb
+++ b/lib/tracking/push.rb
@@ -1,0 +1,14 @@
+require "active_support/json"
+
+module GoogleAnalytics
+  class Push
+
+    def initialize(attributes)
+      @attributes = attributes
+    end
+
+    def write
+      @attributes.to_json
+    end
+  end
+end

--- a/rack-google-analytics.gemspec
+++ b/rack-google-analytics.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_development_dependency 'bundler'
+  s.add_development_dependency 'actionpack'
+  s.add_development_dependency 'activesupport'
   s.add_development_dependency 'test-unit', '~> 2.5.1'
   s.add_development_dependency 'shoulda',   '~> 2.11.3'
   s.add_development_dependency 'rack',      '~> 1.2.0'

--- a/test/test_rack-google-analytics-events.rb
+++ b/test/test_rack-google-analytics-events.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../helper',__FILE__)
 
 class TestRackGoogleAnalyticsEvents < Test::Unit::TestCase
-  
+
   context "Asyncronous With Events" do
     context "default" do
       setup do
@@ -16,6 +16,24 @@ class TestRackGoogleAnalyticsEvents < Test::Unit::TestCase
         assert_match %r{Users}, last_response.body
         assert_match %r{Login}, last_response.body
         assert_match %r{Standard}, last_response.body
+      end
+
+    end
+  end
+
+  context "Asyncronous With Push" do
+    context "default" do
+      setup do
+          events = [GoogleAnalytics::Push.new(["_addItem", "ID", "SKU"])]
+          mock_app :async => true, :tracker => 'somebody', :events => events
+      end
+      should "show events" do
+        get "/"
+
+        assert_match %r{\_gaq\.push}, last_response.body
+        assert_match %r{_addItem.*_trackPageview}m, last_response.body
+        assert_match %r{ID}, last_response.body
+        assert_match %r{SKU}, last_response.body
       end
 
     end

--- a/test/test_rack-google-analytics-instance-methods.rb
+++ b/test/test_rack-google-analytics-instance-methods.rb
@@ -59,7 +59,7 @@ class TestRackGoogleAnalyticsInstanceMethods < Test::Unit::TestCase
       end
 
       should "have custom vars" do
-        get :index
+        get "/"
         assert last_response.ok?
 
         assert_match %r{\_gaq\.push}, last_response.body

--- a/test/test_rack-google-analytics-instance-methods.rb
+++ b/test/test_rack-google-analytics-instance-methods.rb
@@ -17,7 +17,12 @@ class TestRackGoogleAnalyticsInstanceMethods < Test::Unit::TestCase
     def index
       set_ga_custom_var(1, "Items Removed", "Yes", GoogleAnalytics::CustomVar::SESSION_LEVEL)
       track_ga_event("Users", "Login", "Standard")
+      ga_push("_addItem", "ID", "SKU")
       render :inline => "<html><head><title>Title</title></head><body>Hello World</body></html>"
+    end
+
+    def action_method?(name)
+      true
     end
   end
 
@@ -54,13 +59,23 @@ class TestRackGoogleAnalyticsInstanceMethods < Test::Unit::TestCase
       end
 
       should "have custom vars" do
-        get "/"
+        get :index
         assert last_response.ok?
 
         assert_match %r{\_gaq\.push}, last_response.body
         assert_match %r{_setCustomVar.*_trackPageview}m, last_response.body
         assert_match %r{Items Removed}, last_response.body
         assert_match %r{Yes}, last_response.body
+      end
+
+      should "have generic push" do
+        get "/"
+        assert last_response.ok?
+
+        assert_match %r{\_gaq\.push}, last_response.body
+        assert_match %r{_addItem.*_trackPageview}m, last_response.body
+        assert_match %r{ID}, last_response.body
+        assert_match %r{SKU}, last_response.body
       end
     end
   end


### PR DESCRIPTION
Besindes tracking events and custom variables the `ga_push` method will allow you to put generic data into the GA queue. 

One usecase might be the implementation of [e commerce tracking](https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingEcommerce#Example)
