### PR TITLE
Avoid error on redirection when "rack.session" is nil

### DIFF
--- a/lib/rack/google-analytics.rb
+++ b/lib/rack/google-analytics.rb
@@ -6,7 +6,7 @@ module Rack
   class GoogleAnalytics
 
     EVENT_TRACKING_KEY = "google_analytics.event_tracking"
-    
+
     DEFAULT = { :async => true }
 
     def initialize(app, options = {})
@@ -30,14 +30,14 @@ module Rack
         session = env["rack.session"]
         stored_events = session.delete(EVENT_TRACKING_KEY) if session
         @options[:tracker_vars] += stored_events unless stored_events.nil?
-      elsif response.redirection?
+      elsif response.redirection? && env["rack.session"]
         # Store the events until next time
         env["rack.session"][EVENT_TRACKING_KEY] = env[EVENT_TRACKING_KEY]
       end
 
       @body.each { |fragment| response.write inject(fragment) }
       @body.close if @body.respond_to?(:close)
-      
+
       response.finish
     end
 

--- a/rack-google-analytics.gemspec
+++ b/rack-google-analytics.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'actionpack'
   s.add_development_dependency 'activesupport'
-  s.add_development_dependency 'test-unit', '~> 2.5.1'
-  s.add_development_dependency 'shoulda',   '~> 2.11.3'
-  s.add_development_dependency 'rack',      '~> 1.2.0'
-  s.add_development_dependency 'rack-test', '~> 0.5.4'
+  s.add_development_dependency 'test-unit', '~> 2.5'
+  s.add_development_dependency 'shoulda',   '~> 2.11'
+  s.add_development_dependency 'rack',      '~> 1.2'
+  s.add_development_dependency 'rack-test', '~> 0.5'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -31,6 +31,8 @@ class Test::Unit::TestCase
           [200, {'Content-Type' => 'application/xml'}, ['Xml here']]
         when '/bob' then
           [200, {'Content-Type' => 'application/html'}, ['<body>bob here</body>']]
+        when '/redirect' then
+          [302, {'Content-Type' => 'application/html'}, ['<body>redirection</body>']]
         else
           [404, 'Nothing here']
       end

--- a/test/test_rack-google-analytics.rb
+++ b/test/test_rack-google-analytics.rb
@@ -24,6 +24,11 @@ class TestRackGoogleAnalytics < Test::Unit::TestCase
         assert_no_match %r{\_gaq\.push}, last_response.body
         assert_match %r{bob here}, last_response.body
       end
+
+      should "redirects" do
+        get "/redirect"
+        assert_equal 302, last_response.status
+      end
     end
 
     context "multiple sub domains" do


### PR DESCRIPTION
When my server make a redirection without "rack.session" rack-google-analytics raise `NoMethodError: undefined method `[]=' for nil:NilClass` on https://github.com/leehambley/rack-google-analytics/blob/fb76f71fa3becfad1fa08138b301409a07bb0517/lib/rack/google-analytics.rb#L35

This PR fix it.
