### PR TITLE
support doubleclick to display advertising

### DIFF
--- a/lib/rack/google-analytics.rb
+++ b/lib/rack/google-analytics.rb
@@ -7,7 +7,7 @@ module Rack
 
     EVENT_TRACKING_KEY = "google_analytics.event_tracking"
 
-    DEFAULT = { :async => true }
+    DEFAULT = { :async => true, :advertising => false }
 
     def initialize(app, options = {})
       raise ArgumentError, "Tracker must be set!" unless options[:tracker] and !options[:tracker].empty?

--- a/lib/rack/templates/async.erb
+++ b/lib/rack/templates/async.erb
@@ -27,7 +27,11 @@
 
   (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+<% if @options[:advertising] %>
+    ga.src = ('https:' == document.location.protocol ? 'https://' : 'http://') + 'stats.g.doubleclick.net/dc.js';
+<% else %>
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+<% end %>
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
 

--- a/test/test_rack-google-analytics.rb
+++ b/test/test_rack-google-analytics.rb
@@ -66,6 +66,14 @@ class TestRackGoogleAnalytics < Test::Unit::TestCase
       end
     end
 
+    context "with advertising option" do
+      setup { mock_app :async => true, :tracker => 'happy', :advertising => true }
+      should "use doubleclick script" do
+        get "/"
+        assert_match %r{stats.g.doubleclick.net/dc.js}, last_response.body
+      end
+    end
+
   end
 
   context "Syncronous" do


### PR DESCRIPTION
using doubleclick.net script instead of google-analytics.

see it: https://support.google.com/analytics/answer/2444872?hl=en&utm_id=ad

Usage:

use Rack::GoogleAnalytics, :tracker => 'UA-xxxxx-x', :advertising => true
