### PR TITLE
Add activesupport dependency

### DIFF
--- a/rack-google-analytics.gemspec
+++ b/rack-google-analytics.gemspec
@@ -16,9 +16,10 @@ Gem::Specification.new do |s|
   s.files        = Dir.glob("lib/**/*") + %w(README.md LICENSE)
   s.require_path = 'lib'
 
+  s.add_dependency 'activesupport'
+
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'actionpack'
-  s.add_development_dependency 'activesupport'
   s.add_development_dependency 'test-unit', '~> 2.5'
   s.add_development_dependency 'shoulda',   '~> 2.11'
   s.add_development_dependency 'rack',      '~> 1.2'


### PR DESCRIPTION
https://github.com/kangguru/rack-google-analytics/blob/master/lib/rack-google-analytics.rb#L1 requires activesupport so we need to add it as a dependency.

Figured that, when trying to add it to octostalker https://github.com/arthurnn/octostalker/commit/9d8452adcf841e4fd87baf20e96368af9259680e . See that I had to add activesupport otherwise it wouldnt work.
