### PR TITLE
Lambda-based tracking code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ In your application controller, you may push arbritrary data. For example:
 ga_push("_addItem", "ID", "SKU")
 ```
 
+## Dynamic Tracking Code
+
+You may instead define your tracking code as a lambda taking the Rack environment, so that you may set the tracking code
+dynamically based upon information in the Rack environment. For example:
+
+```ruby
+config.middleware.use Rack::GoogleAnalytics, :tracker => lambda { |env|
+        return env[:site_ga].tracker if env[:site_ga]
+}
+```
+
 
 ## Thread Safety
 

--- a/lib/rack/templates/async.erb
+++ b/lib/rack/templates/async.erb
@@ -1,7 +1,7 @@
 <script type="text/javascript">
 
   var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', <%= @options[:tracker].inspect %>]);
+  _gaq.push(['_setAccount', <%= @tracker.inspect %>]);
 <% if @options[:multiple] %>
   _gaq.push(['_setDomainName', <%= @options[:domain].inspect %>]);
 <% end %>

--- a/lib/rack/templates/sync.erb
+++ b/lib/rack/templates/sync.erb
@@ -4,7 +4,7 @@ document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.
 </script>
 <script type="text/javascript">
 try{
-var pageTracker = _gat._getTracker(<%= @options[:tracker].inspect %>);
+var pageTracker = _gat._getTracker(<%= @tracker.inspect %>);
 <% if @options[:anonymize_ip] %>
 _gat._anonymizeIp();
 <% end %>

--- a/test/test_rack-google-analytics.rb
+++ b/test/test_rack-google-analytics.rb
@@ -31,6 +31,18 @@ class TestRackGoogleAnalytics < Test::Unit::TestCase
       end
     end
 
+    context "dynamic tracker" do
+      context "well-formed result" do
+        setup { mock_app :async => true, :tracker =>
+            lambda { |env| return 'dynamictracker'}}
+
+        should 'call tracker lambdas to obtain tracking codes' do
+          get '/'
+          assert_match %r{\'\_setAccount\', \"dynamictracker\"}, last_response.body
+        end
+      end
+    end
+
     context "multiple sub domains" do
       setup { mock_app :async => true, :multiple => true, :tracker => 'gonna', :domain => 'mydomain.com' }
       should "add multiple domain script" do


### PR DESCRIPTION
We had a set of scenarios in which we wanted an application to be able dynamically specify the tracking code based on whatever business logic needed to govern it. This PR adds support for optionally passing a lambda that provides the tracking code at runtime based on the Rack environment.

With this change a site can define a tracker like

``` ruby
 config.middleware.use Rack::GoogleAnalytics, :tracker => lambda { |env| 
  return env[:site_ga].tracker if env[:site_ga]
}
```

and then vary the tracking code dynamically based on whatever logic it wants, a contrived example being:

``` ruby
class WelcomeController < ApplicationController
  def index
    env[:site_ga] = OpenStruct.new(:tracker => "abc123")
  end
end
```
