### PR TITLE
Custom adjusted bounce rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ config.middleware.use Rack::GoogleAnalytics, :tracker => 'UA-xxxxxx-x'
 * `:top_level`  -  sets tracker for multiple top-level domains. (must also set :domain)
 * `:anonymize_ip` -  sets the tracker to remove the last octet from all IP addresses, see https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApi_gat?hl=de#_gat._anonymizeIp for details.
 * `:site_speed_sample_rate` - Defines a new sample set size for Site Speed data collection, see https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiBasicConfiguration?hl=de#_gat.GA_Tracker_._setSiteSpeedSampleRate
+* `:adjusted_bounce_rate_timeouts` - An array of times in seconds that the tracker will use to set
+timeouts for adjusted bounce rate tracking. See http://analytics.blogspot.ca/2012/07/tracking-adjusted-bounce-rate-in-google.html for details.
 
 Note: since 0.2.0 this will use the asynchronous Google Analytics tracking code, for the traditional behaviour please use:
 

--- a/lib/rack/templates/async.erb
+++ b/lib/rack/templates/async.erb
@@ -23,6 +23,11 @@
 <% end
   end
    %>
+<% if @options[:adjusted_bounce_rate_timeouts] %>
+<% @options[:adjusted_bounce_rate_timeouts].each do |timeout| %>
+    setTimeout("_gaq.push(['_trackEvent', <%= "#{timeout.to_s}_seconds" %>, 'read'])",<%= timeout*1000 %>);
+<% end %>
+<% end %>
   _gaq.push(['_trackPageview']);
 
   (function() {
@@ -30,5 +35,4 @@
     ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
-
 </script>

--- a/test/test_rack-google-analytics.rb
+++ b/test/test_rack-google-analytics.rb
@@ -26,6 +26,15 @@ class TestRackGoogleAnalytics < Test::Unit::TestCase
       end
     end
 
+    context 'adjusted bounce rate' do
+      setup { mock_app :async => true, :tracker => 'afake', :adjusted_bounce_rate_timeouts => [15, 30] }
+      should "add timeouts to push read events" do
+        get "/"
+        assert_match %r{'_trackEvent', 15_seconds}, last_response.body
+        assert_match %r{'_trackEvent', 30_seconds}, last_response.body
+      end
+    end
+
     context "multiple sub domains" do
       setup { mock_app :async => true, :multiple => true, :tracker => 'gonna', :domain => 'mydomain.com' }
       should "add multiple domain script" do


### PR DESCRIPTION
We have sets of pages for which it's useful to implement Adjusted Bounce Rates analytics to get a better idea of how much user engagement our articles are generating, per Google's documentation of the concept (http://analytics.blogspot.ca/2012/07/tracking-adjusted-bounce-rate-in-google.html). This PR adds simple support for specifying time intervals at which tracking events should be generated for calculating such adjusted bounce rates.
