### PR TITLE
:if option that accepts lambdas added to skip middleware

### DIFF
--- a/lib/rack/google-analytics.rb
+++ b/lib/rack/google-analytics.rb
@@ -19,6 +19,8 @@ module Rack
     def _call(env)
       @status, @headers, @body = @app.call(env)
       return [@status, @headers, @body] unless html?
+      return [@status, @headers, @body] if skip?(env)
+
       response = Rack::Response.new([], @status, @headers)
       @options[:tracker_vars] = env["google_analytics.custom_vars"] || []
 
@@ -67,6 +69,12 @@ module Rack
     def tracker(env, tracker)
       return tracker unless tracker.respond_to?(:call)
       return tracker.call(env)
+    end
+
+    def skip?(env)
+      return false if @options[:if].nil?
+      return !@options[:if] unless @options[:if].respond_to?(:call)
+      return !@options[:if].call(env)
     end
 
   end

--- a/test/test_rack-google-analytics.rb
+++ b/test/test_rack-google-analytics.rb
@@ -31,6 +31,24 @@ class TestRackGoogleAnalytics < Test::Unit::TestCase
       end
     end
 
+    context ":if option" do
+      context "returns true" do
+        setup { mock_app :async => true, :tracker => 'somebody', :if =>  lambda { |env| return true} }
+        should "add tracker" do
+            get "/"
+            assert_match %r{\_gaq\.push}, last_response.body
+        end
+      end
+
+      context "returns false" do
+        setup { mock_app :async => true, :tracker => 'somebody', :if =>  lambda { |env| return false} }
+        should "not add tracker" do
+            get "/"
+            assert_no_match %r{\_gaq\.push}, last_response.body
+        end
+      end
+    end
+
     context 'adjusted bounce rate' do
       setup { mock_app :async => true, :tracker => 'afake', :adjusted_bounce_rate_timeouts => [15, 30] }
       should "add timeouts to push read events" do


### PR DESCRIPTION
`:if` option added to skip google analytics if returns false. 

A `lambda` might be used, so we can do something like 

```
Rack::GoogleAnalytics, 
    :tracker => lambda { |env| return env[:ga_tracking_code] },
    :if => lambda { |env| return !env[:ga_tracking_code].nil? }
```

We can check for any of the variables of in `env`.

It would be possible to disabled GA for `controllers` or `controllers actions` using `before_filter` 
