### PR TITLE
Support Display Advertising features

### DIFF
--- a/lib/rack/google-analytics.rb
+++ b/lib/rack/google-analytics.rb
@@ -6,7 +6,7 @@ module Rack
   class GoogleAnalytics
 
     EVENT_TRACKING_KEY = "google_analytics.event_tracking"
-    DEFAULT = { async: true, enhanced_link_attribution: false }
+    DEFAULT = { async: true, enhanced_link_attribution: false, advertising: false }
 
     def initialize(app, options = {})
       @app, @options = app, DEFAULT.merge(options)

--- a/lib/rack/templates/async.erb
+++ b/lib/rack/templates/async.erb
@@ -31,6 +31,11 @@
 <% end
   end
    %>
+
+<% if @options[:advertising] %>
+  ga('require', 'displayfeatures');
+<% end %>
+
 <% if @options[:tracker] %>
    ga('send', 'pageview');
 <% end %>

--- a/test/test_rack-google-analytics.rb
+++ b/test/test_rack-google-analytics.rb
@@ -53,6 +53,14 @@ class TestRackGoogleAnalytics < Test::Unit::TestCase
       end
     end
 
+    context "with advertising" do
+      setup { mock_app tracker: 'happy', advertising: true }
+      should "require displayfeatures" do
+        get "/"
+        assert_match %r{ga\('require', 'displayfeatures'\)}, last_response.body
+      end
+    end
+
     context "with anonymizeIp" do
       setup { mock_app :async => true, :tracker => 'happy', :anonymize_ip => true }
       should "set anonymizeIp to true" do


### PR DESCRIPTION
Universal Analytics supported display advertising features.

see it: https://support.google.com/analytics/answer/2444872?hl=en&utm_id=ad

Usage

``` ruby
use Rack::GoogleAnalytics, :tracker => 'UA-xxxxx-x', :advertising => true
```
