### PR TITLE
Add track_pageview option to make it easier to use with Turbolinks

### DIFF
--- a/lib/rack/google-analytics.rb
+++ b/lib/rack/google-analytics.rb
@@ -6,7 +6,7 @@ module Rack
   class GoogleAnalytics
 
     EVENT_TRACKING_KEY = "google_analytics.event_tracking"
-    DEFAULT = { async: true, enhanced_link_attribution: false, advertising: false }
+    DEFAULT = { async: true, enhanced_link_attribution: false, advertising: false, track_pageview: true }
 
     def initialize(app, options = {})
       @app, @options = app, DEFAULT.merge(options)

--- a/lib/rack/templates/async.erb
+++ b/lib/rack/templates/async.erb
@@ -40,7 +40,7 @@
   ga('require', 'ecommerce', 'ecommerce.js');
 <% end %>
 
-<% if @options[:tracker] %>
+<% if @options[:tracker] && @options[:track_pageview] %>
    ga('send', 'pageview');
 <% end %>
 

--- a/test/test_rack-google-analytics.rb
+++ b/test/test_rack-google-analytics.rb
@@ -32,6 +32,20 @@ class TestRackGoogleAnalytics < Test::Unit::TestCase
       end
     end
 
+    context "with disabled pageview tracking" do
+      setup { mock_app tracker: 'somebody', track_pageview: false }
+      should "show asyncronous tracker" do
+        get "/"
+        assert_match %r{ga\('create', 'somebody', {}\)}, last_response.body
+        assert_match %r{</script></head>}, last_response.body
+      end
+
+      should "not track pageview" do
+        get "/"
+        assert_no_match %r{ga\('send', 'pageview'\)}, last_response.body
+      end
+    end
+
     context "with custom domain" do
       setup { mock_app tracker: 'somebody', domain: "railslabs.com" }
 


### PR DESCRIPTION
This pull request adds a `track_pageview` option (which is `true` by default, to keep existing behavior). When used, it does not output the `ga('send', 'pageview')` line in the tracker code.

We’re using this to make the middleware play nice with [Turbolinks](https://github.com/rails/turbolinks) which does not evaluate `<script>` tags in the `<head>` when changing pages. This new `track_pageview` option allows us to have this code in the `<head>`.

``` html
<head>
  …

  <script type="text/javascript">
    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');

    ga('create', 'UA-0000000-01', {});
  </script>
</head>
<body>
  …
</body>
```

And manually track our pageviews in a `<script>` element at the end of our `<body>` (**which gets evaluated by Turbolinks when it changes the page content**)

``` html
<head>
  …
</head>
<body>
  …
  <script>
    if (window.ga) { ga('send', 'pageview'); }
  </script>
</body>
```

What do you think? It doesn’t do anything if the option is not used :smile: 
