### PR TITLE
Memorize old events on multiple redirects

### DIFF
--- a/lib/rack/google-analytics.rb
+++ b/lib/rack/google-analytics.rb
@@ -20,17 +20,17 @@ module Rack
       response = Rack::Response.new([], @status, @headers)
       @options[:tracker_vars] = env["google_analytics.custom_vars"] || []
 
+      # Get any stored events from a redirection
+      stored_events = env["rack.session"].delete(EVENT_TRACKING_KEY) if env["rack.session"]
+
       if response.ok?
         # Write out the events now
         @options[:tracker_vars] += (env[EVENT_TRACKING_KEY]) unless env[EVENT_TRACKING_KEY].nil?
-
-        # Get any stored events from a redirection
-        session = env["rack.session"]
-        stored_events = session.delete(EVENT_TRACKING_KEY) if session
         @options[:tracker_vars] += stored_events unless stored_events.nil?
       elsif response.redirection? && env["rack.session"]
         # Store the events until next time
-        env["rack.session"][EVENT_TRACKING_KEY] = env[EVENT_TRACKING_KEY]
+        events_to_be_stored = (env[EVENT_TRACKING_KEY] || []) + (stored_events || [])
+        env["rack.session"][EVENT_TRACKING_KEY] = events_to_be_stored unless events_to_be_stored.empty?
       end
 
       @options[:tracker] = expand_tracker(env, @options[:tracker])

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,6 +22,7 @@ class Test::Unit::TestCase
       env["google_analytics.event_tracking"] = options[:events] if options[:events]
       env["google_analytics.custom_vars"] = options[:custom_vars] if options[:custom_vars]
       env["misc"] = options[:misc] if options[:misc]
+      env['rack.session'] = options[:rack_session] if options[:rack_session]
 
       request = Rack::Request.new(env)
       case request.path
@@ -40,7 +41,7 @@ class Test::Unit::TestCase
   end
 
   def mock_app(options)
-    app_options = options.slice(:events, :custom_vars, :misc)
+    app_options = options.slice(:events, :custom_vars, :misc, :rack_session)
 
     builder = Rack::Builder.new
     builder.use Rack::GoogleAnalytics, options


### PR DESCRIPTION
On a redirect the middleware only stores new events from the current call. Old events stored in rack.session will be lost on the second redirect.
