### PR TITLE
Allow multiple trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ config.middleware.use Rack::GoogleAnalytics, :tracker => 'UA-xxxxxx-x'
 
 ### Options
 
+* `:tracker` - sets the Google Analytics tracker
+* `:trackers` - array of arrays to set multiple trackers. Takes the form `[['name1', 'tracker1'], ['name2', 'tracker2'], ...]`. Note that `name1` in this example will be ignored because the first tracker is the default. All additional trackers must be named. See https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#multipletrackers for details.
 * `:anonymize_ip` -  sets the tracker to remove the last octet from all IP addresses, see https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApi_gat?hl=de#_gat._anonymizeIp for details.
 * `:domain`     -  sets the domain name for the GATC cookies. Defaults to `auto`.
 * `:site_speed_sample_rate` - Defines a new sample set size for Site Speed data collection, see https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiBasicConfiguration?hl=de#_gat.GA_Tracker_._setSiteSpeedSampleRate

--- a/lib/rack/google-analytics.rb
+++ b/lib/rack/google-analytics.rb
@@ -46,7 +46,7 @@ module Rack
     def html?; @headers['Content-Type'] =~ /html/; end
 
     def inject(response)
-      @tracker_options = { cookieDomain: @options[:domain] }.select{|k,v| v }.to_json
+      @tracker_options = { cookieDomain: @options[:domain] }.select{|k,v| v }
       @template ||= ::ERB.new ::File.read ::File.expand_path("../templates/async.erb",__FILE__)
 
       response.gsub(%r{</head>}, @template.result(binding) + "</head>")

--- a/lib/rack/google-analytics.rb
+++ b/lib/rack/google-analytics.rb
@@ -33,12 +33,14 @@ module Rack
         env["rack.session"][EVENT_TRACKING_KEY] = env[EVENT_TRACKING_KEY]
       end
 
-      @options[:tracker] = expand_tracker(env, @options[:tracker])
-      @options[:trackers] = expand_trackers(env, @options[:trackers])
+      @tracker = expand_tracker(env, @options[:tracker])
+      @trackers = expand_trackers(env, @options[:trackers])
 
       @body.each { |fragment| response.write inject(fragment) }
       @body.close if @body.respond_to?(:close)
 
+      @tracker = nil
+      @trackers = nil
       response.finish
     end
 
@@ -49,7 +51,6 @@ module Rack
     def inject(response)
       @tracker_options = { cookieDomain: @options[:domain] }.select{|k,v| v }
       @template ||= ::ERB.new ::File.read ::File.expand_path("../templates/async.erb",__FILE__)
-
       response.gsub(%r{</head>}, @template.result(binding) + "</head>")
     end
 

--- a/lib/rack/google-analytics.rb
+++ b/lib/rack/google-analytics.rb
@@ -34,6 +34,7 @@ module Rack
       end
 
       @options[:tracker] = expand_tracker(env, @options[:tracker])
+      @options[:trackers] = expand_trackers(env, @options[:trackers])
 
       @body.each { |fragment| response.write inject(fragment) }
       @body.close if @body.respond_to?(:close)
@@ -54,6 +55,10 @@ module Rack
 
     def expand_tracker(env, tracker)
       tracker.respond_to?(:call) ? tracker.call(env) : tracker
+    end
+
+    def expand_trackers(env, trackers)
+      trackers.respond_to?(:call) ? trackers.call(env) : trackers
     end
 
   end

--- a/lib/rack/templates/async.erb
+++ b/lib/rack/templates/async.erb
@@ -7,11 +7,11 @@
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
   <% if @options[:tracker] %>
-    ga('create', '<%= @options[:tracker] %>', <%= @tracker_options %>);
+    ga('create', '<%= @options[:tracker] %>', <%= @tracker_options.to_json %>);
   <% else %>
     <% @options[:trackers].each_with_index do |pair, i| %>
       <% name, tracker = pair %>
-      ga('create', '<%= tracker %>', <%= @tracker_options %>)<%= ", {'name': '#{name}'}" if i > 0 %>;
+      ga('create', '<%= tracker %>', <%= (i > 0 ? @tracker_options.merge(:name => name) : @tracker_options).to_json %>);
     <% end %>
   <% end %>
 

--- a/lib/rack/templates/async.erb
+++ b/lib/rack/templates/async.erb
@@ -1,15 +1,15 @@
 <script type="text/javascript">
 
-<% if @options[:tracker] || @options[:trackers] %>
+<% if @tracker || @trackers %>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  <% if @options[:tracker] %>
-    ga('create', '<%= @options[:tracker] %>', <%= @tracker_options.to_json %>);
+  <% if @tracker %>
+    ga('create', '<%= @tracker %>', <%= @tracker_options.to_json %>);
   <% else %>
-    <% @options[:trackers].each_with_index do |pair, i| %>
+    <% @trackers.each_with_index do |pair, i| %>
       <% name, tracker = pair %>
       ga('create', '<%= tracker %>', <%= (i > 0 ? @tracker_options.merge(:name => name) : @tracker_options).to_json %>);
     <% end %>
@@ -47,10 +47,10 @@
   ga('require', 'ecommerce', 'ecommerce.js');
 <% end %>
 
-<% if @options[:tracker] %>
+<% if @tracker %>
   ga('send', 'pageview');
-<% elsif @options[:trackers] %>
-  <% @options[:trackers].each_with_index do |pair, i| %>
+<% elsif @trackers %>
+  <% @trackers.each_with_index do |pair, i| %>
     <% name, tracker = pair %>
     <% if i == 0 %>
       ga('send', 'pageview');

--- a/lib/rack/templates/async.erb
+++ b/lib/rack/templates/async.erb
@@ -1,12 +1,19 @@
 <script type="text/javascript">
 
-<% if @options[:tracker] %>
+<% if @options[:tracker] || @options[:trackers] %>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-  ga('create', '<%= @options[:tracker] %>', <%= @tracker_options %>);
+  <% if @options[:tracker] %>
+    ga('create', '<%= @options[:tracker] %>', <%= @tracker_options %>);
+  <% else %>
+    <% @options[:trackers].each_with_index do |pair, i| %>
+      <% name, tracker = pair %>
+      ga('create', '<%= tracker %>', <%= @tracker_options %>)<%= ", {'name': '#{name}'}" if i > 0 %>;
+    <% end %>
+  <% end %>
 
 <% if @options[:enhanced_link_attribution] %>
   ga('require', 'linkid', 'linkid.js');
@@ -41,7 +48,16 @@
 <% end %>
 
 <% if @options[:tracker] %>
-   ga('send', 'pageview');
+  ga('send', 'pageview');
+<% elsif @options[:trackers] %>
+  <% @options[:trackers].each_with_index do |pair, i| %>
+    <% name, tracker = pair %>
+    <% if i == 0 %>
+      ga('send', 'pageview');
+    <% else %>
+      ga('<%= name %>.send', 'pageview');
+    <% end %>
+  <% end %>
 <% end %>
 
 </script>

--- a/test/test_rack-google-analytics.rb
+++ b/test/test_rack-google-analytics.rb
@@ -99,6 +99,20 @@ class TestRackGoogleAnalytics < Test::Unit::TestCase
       end
     end
 
+    context "with multiple trackers" do
+      setup { mock_app trackers: [['name1','horchata'], ['name2','slurpee']]}
+      should "show multiple trackers" do
+        get "/"
+        assert_match %r{ga\('create', 'horchata', {}\)}, last_response.body
+        assert_match %r{ga\('create', 'slurpee', {}\)}, last_response.body
+      end
+      should "should trigger pageview for each tracker" do
+        get "/"
+        assert_match %r{ga\('send', 'pageview'\);}, last_response.body
+        assert_match %r{ga\('name2.send', 'pageview'\);}, last_response.body
+      end
+    end
+
     # context "with custom _setSiteSpeedSampleRate" do
     #   setup { mock_app :async => true, :tracker => 'happy', :site_speed_sample_rate => 5 }
     #   should "add top_level domain script" do

--- a/test/test_rack-google-analytics.rb
+++ b/test/test_rack-google-analytics.rb
@@ -104,7 +104,7 @@ class TestRackGoogleAnalytics < Test::Unit::TestCase
       should "show multiple trackers" do
         get "/"
         assert_match %r{ga\('create', 'horchata', {}\)}, last_response.body
-        assert_match %r{ga\('create', 'slurpee', {}\)}, last_response.body
+        assert_match %r{ga\('create', 'slurpee', {"name":"name2"}\)}, last_response.body
       end
       should "should trigger pageview for each tracker" do
         get "/"

--- a/test/test_rack-google-analytics.rb
+++ b/test/test_rack-google-analytics.rb
@@ -86,6 +86,15 @@ class TestRackGoogleAnalytics < Test::Unit::TestCase
         get '/'
         assert_match %r{ga\('create', 'foobar', {}\)}, last_response.body
       end
+
+      # TODO couldn't figure out how to alter the env for the same app
+      # should 'call tracker lambdas for each request' do
+      #   get '/'
+      #   assert_match %r{ga\('create', 'foobar', {}\)}, last_response.body
+      #   # TODO magically change env['misc'] to "beeblebrax"
+      #   get '/'
+      #   assert_match %r{ga\('create', 'beeblebrax', {}\)}, last_response.body
+      # end
     end
 
     context 'adjusted bounce rate' do

--- a/test/test_rack-google-analytics.rb
+++ b/test/test_rack-google-analytics.rb
@@ -113,6 +113,19 @@ class TestRackGoogleAnalytics < Test::Unit::TestCase
       end
     end
 
+    context "with multiple trackers block" do
+      setup do
+        mock_app trackers: lambda {|env|
+          [['name1','horchata'], ['name2','slurpee']]
+        }
+      end
+      should "show multiple trackers" do
+        get "/"
+        assert_match %r{ga\('create', 'horchata', {}\)}, last_response.body
+        assert_match %r{ga\('create', 'slurpee', {"name":"name2"}\)}, last_response.body
+      end
+    end
+
     # context "with custom _setSiteSpeedSampleRate" do
     #   setup { mock_app :async => true, :tracker => 'happy', :site_speed_sample_rate => 5 }
     #   should "add top_level domain script" do


### PR DESCRIPTION
This allows you to specify multiple trackers as an array of arrays, e.g. `[['name1','horchata'], ['name2','slurpee']]`, or as a block that gets called with each request. The first tracker doesn't really require a name, but the subsequent ones do.
